### PR TITLE
refactor: use u8 for copy_index

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,7 +180,7 @@ pub struct NpmPackageCacheFolderId {
   pub nv: NpmPackageNv,
   /// Peer dependency resolution may require us to have duplicate copies
   /// of the same package.
-  pub copy_index: usize,
+  pub copy_index: u8,
 }
 
 impl NpmPackageCacheFolderId {
@@ -209,7 +209,7 @@ pub struct NpmResolutionPackage {
   /// package (name and version) depending on where it is in
   /// the resolution tree. This copy index indicates which
   /// copy of the package this is.
-  pub copy_index: usize,
+  pub copy_index: u8,
   pub dist: NpmPackageVersionDistInfo,
   /// Key is what the package refers to the other package as,
   /// which could be different from the package name.

--- a/src/resolution/common.rs
+++ b/src/resolution/common.rs
@@ -93,14 +93,12 @@ fn get_resolved_package_version_and_info<'a>(
 
     match maybe_best_version {
       Some(v) => Ok(v),
-      // If the package isn't found, it likely means that the user needs to use
-      // `--reload` in the CLI to get the latest npm package information. Although
-      // it seems like we could make this smart by fetching the latest information for
-      // this package here, we really need a full restart. There could be very
-      // interesting bugs that occur if this package's version was resolved by
-      // something previous using the old information, then now being smart here
-      // causes a new fetch of the package information, meaning this time the
-      // previous resolution of this package's version resolved to an older
+      // Although it seems like we could make this smart by fetching the latest
+      // information for this package here, we really need a full restart. There
+      // could be very interesting bugs that occur if this package's version was
+      // resolved by something previous using the old information, then now being
+      // smart here causes a new fetch of the package information, meaning this
+      // time the previous resolution of this package's version resolved to an older
       // version, but next time to a different version because it has new information.
       None => Err(NpmPackageVersionResolutionError::VersionReqNotMatched {
         package_name: info.name.clone(),

--- a/src/resolution/graph.rs
+++ b/src/resolution/graph.rs
@@ -331,7 +331,7 @@ pub struct Graph {
   resolved_node_ids: ResolvedNodeIds,
   // This will be set when creating from a snapshot, then
   // inform the final snapshot creation.
-  packages_to_copy_index: HashMap<NpmPackageId, usize>,
+  packages_to_copy_index: HashMap<NpmPackageId, u8>,
   /// Packages that the resolver should resolve first.
   pending_unresolved_packages: Vec<Arc<NpmPackageNv>>,
 }
@@ -3659,7 +3659,7 @@ mod test {
   #[derive(Debug, PartialEq, Eq)]
   struct TestNpmResolutionPackage {
     pub pkg_id: String,
-    pub copy_index: usize,
+    pub copy_index: u8,
     pub dependencies: BTreeMap<String, String>,
   }
 

--- a/src/resolution/snapshot.rs
+++ b/src/resolution/snapshot.rs
@@ -498,8 +498,8 @@ impl NpmResolutionSnapshot {
 }
 
 pub struct SnapshotPackageCopyIndexResolver {
-  packages_to_copy_index: HashMap<NpmPackageId, usize>,
-  package_name_version_to_copy_count: HashMap<NpmPackageNv, usize>,
+  packages_to_copy_index: HashMap<NpmPackageId, u8>,
+  package_name_version_to_copy_count: HashMap<NpmPackageNv, u8>,
 }
 
 impl SnapshotPackageCopyIndexResolver {
@@ -511,7 +511,7 @@ impl SnapshotPackageCopyIndexResolver {
   }
 
   pub fn from_map_with_capacity(
-    mut packages_to_copy_index: HashMap<NpmPackageId, usize>,
+    mut packages_to_copy_index: HashMap<NpmPackageId, u8>,
     capacity: usize,
   ) -> Self {
     let mut package_name_version_to_copy_count =
@@ -534,7 +534,7 @@ impl SnapshotPackageCopyIndexResolver {
     }
   }
 
-  pub fn resolve(&mut self, node_id: &NpmPackageId) -> usize {
+  pub fn resolve(&mut self, node_id: &NpmPackageId) -> u8 {
     if let Some(index) = self.packages_to_copy_index.get(node_id) {
       *index
     } else {


### PR DESCRIPTION
It would be extraordinary for this value to even get about 10 ever, so I think might as well use a u8 and see what happens.