### PR TITLE
refactor: remove `Arc<Mutex<T>>` usages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ log = "0.4"
 once_cell = "1.17.1"
 serde = { version = "1.0.130", features = ["derive", "rc"] }
 thiserror = "1.0.24"
-parking_lot = "0.12.1"
 futures = "0.3.28"
 
 [dev-dependencies]
+parking_lot = "0.12.1"
 pretty_assertions = "1.0.0"
 serde_json = { version = "1.0.67", features = ["preserve_order"] }
 tokio = { version = "1.27.0", features = ["full"] }

--- a/src/resolution/graph.rs
+++ b/src/resolution/graph.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
+use std::cell::RefCell;
 use std::collections::hash_map::DefaultHasher;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
@@ -7,6 +8,7 @@ use std::collections::HashSet;
 use std::collections::VecDeque;
 use std::hash::Hash;
 use std::hash::Hasher;
+use std::rc::Rc;
 use std::sync::Arc;
 
 use deno_semver::npm::NpmPackageNv;
@@ -76,7 +78,7 @@ enum ResolvedIdPeerDep {
   /// change from under it.
   ParentReference {
     parent: GraphPathNodeOrRoot,
-    child_pkg_nv: Arc<NpmPackageNv>,
+    child_pkg_nv: Rc<NpmPackageNv>,
   },
   /// A node that was created during snapshotting and is not being used in any path.
   SnapshotNodeId(NodeId),
@@ -112,7 +114,7 @@ impl ResolvedIdPeerDep {
 /// will become fully resolved to an `NpmPackageId`.
 #[derive(Clone)]
 struct ResolvedId {
-  nv: Arc<NpmPackageNv>,
+  nv: Rc<NpmPackageNv>,
   peer_dependencies: Vec<ResolvedIdPeerDep>,
 }
 
@@ -178,32 +180,29 @@ impl ResolvedNodeIds {
   }
 }
 
-// todo(dsherret): the lsp errors when using an Rc<RefCell<NodeId>> here
-// instead of an Arc<Mutex<NodeId>>. See https://github.com/denoland/deno/issues/18079
-
 /// A pointer to a specific node in a graph path. The underlying node id
 /// may change as peer dependencies are created.
 #[derive(Clone, Debug)]
-struct NodeIdRef(Arc<Mutex<NodeId>>);
+struct NodeIdRef(Rc<RefCell<NodeId>>);
 
 impl NodeIdRef {
   pub fn new(node_id: NodeId) -> Self {
-    NodeIdRef(Arc::new(Mutex::new(node_id)))
+    NodeIdRef(Rc::new(RefCell::new(node_id)))
   }
 
   pub fn change(&self, node_id: NodeId) {
-    *self.0.lock() = node_id;
+    *self.0.borrow_mut() = node_id;
   }
 
   pub fn get(&self) -> NodeId {
-    *self.0.lock()
+    *self.0.borrow()
   }
 }
 
 #[derive(Clone)]
 enum GraphPathNodeOrRoot {
-  Node(Arc<GraphPath>),
-  Root(Arc<NpmPackageNv>),
+  Node(Rc<GraphPath>),
+  Root(Rc<NpmPackageNv>),
 }
 
 /// Path through the graph that represents a traversal through the graph doing
@@ -216,15 +215,15 @@ struct GraphPath {
   specifier: String,
   // we could consider not storing this here and instead reference the resolved
   // nodes, but we should performance profile this code first
-  nv: Arc<NpmPackageNv>,
+  nv: Rc<NpmPackageNv>,
   /// Descendants in the path that circularly link to an ancestor in a child.These
   /// descendants should be kept up to date and always point to this node.
-  linked_circular_descendants: Mutex<Vec<Arc<GraphPath>>>,
+  linked_circular_descendants: Mutex<Vec<Rc<GraphPath>>>,
 }
 
 impl GraphPath {
-  pub fn for_root(node_id: NodeId, nv: Arc<NpmPackageNv>) -> Arc<Self> {
-    Arc::new(Self {
+  pub fn for_root(node_id: NodeId, nv: Rc<NpmPackageNv>) -> Rc<Self> {
+    Rc::new(Self {
       previous_node: Some(GraphPathNodeOrRoot::Root(nv.clone())),
       node_id_ref: NodeIdRef::new(node_id),
       // use an empty specifier
@@ -247,12 +246,12 @@ impl GraphPath {
   }
 
   pub fn with_id(
-    self: &Arc<GraphPath>,
+    self: &Rc<GraphPath>,
     node_id: NodeId,
     specifier: String,
-    nv: Arc<NpmPackageNv>,
-  ) -> Arc<Self> {
-    Arc::new(Self {
+    nv: Rc<NpmPackageNv>,
+  ) -> Rc<Self> {
+    Rc::new(Self {
       previous_node: Some(GraphPathNodeOrRoot::Node(self.clone())),
       node_id_ref: NodeIdRef::new(node_id),
       specifier,
@@ -262,7 +261,7 @@ impl GraphPath {
   }
 
   /// Gets if there is an ancestor with the same name & version along this path.
-  pub fn find_ancestor(&self, nv: &NpmPackageNv) -> Option<Arc<GraphPath>> {
+  pub fn find_ancestor(&self, nv: &NpmPackageNv) -> Option<Rc<GraphPath>> {
     let mut maybe_next_node = self.previous_node.as_ref();
     while let Some(GraphPathNodeOrRoot::Node(next_node)) = maybe_next_node {
       // we've visited this before, so stop
@@ -278,7 +277,7 @@ impl GraphPath {
   pub fn get_path_to_ancestor_exclusive(
     &self,
     ancestor_node_id: NodeId,
-  ) -> Vec<&Arc<GraphPath>> {
+  ) -> Vec<&Rc<GraphPath>> {
     let mut path = Vec::new();
     let mut maybe_next_node = self.previous_node.as_ref();
     while let Some(GraphPathNodeOrRoot::Node(next_node)) = maybe_next_node {
@@ -319,11 +318,11 @@ impl<'a> Iterator for GraphPathAncestorIterator<'a> {
 
 pub struct Graph {
   /// Each requirement is mapped to a specific name and version.
-  package_reqs: HashMap<NpmPackageReq, Arc<NpmPackageNv>>,
+  package_reqs: HashMap<NpmPackageReq, Rc<NpmPackageNv>>,
   /// Then each name and version is mapped to an exact node id.
   /// Note: Uses a BTreeMap in order to create some determinism
   /// when creating the snapshot.
-  root_packages: BTreeMap<Arc<NpmPackageNv>, NodeId>,
+  root_packages: BTreeMap<Rc<NpmPackageNv>, NodeId>,
   package_name_versions: HashMap<String, HashSet<Version>>,
   nodes: HashMap<NodeId, Node>,
   resolved_node_ids: ResolvedNodeIds,
@@ -331,7 +330,7 @@ pub struct Graph {
   // inform the final snapshot creation.
   packages_to_copy_index: HashMap<NpmPackageId, u8>,
   /// Packages that the resolver should resolve first.
-  pending_unresolved_packages: Vec<Arc<NpmPackageNv>>,
+  pending_unresolved_packages: Vec<Rc<NpmPackageNv>>,
 }
 
 impl Graph {
@@ -364,7 +363,7 @@ impl Graph {
         })
         .collect::<Vec<_>>();
       let graph_resolved_id = ResolvedId {
-        nv: Arc::new(pkg_id.nv.clone()),
+        nv: Rc::new(pkg_id.nv.clone()),
         peer_dependencies: peer_dep_ids,
       };
       graph.resolved_node_ids.set(node_id, graph_resolved_id);
@@ -398,12 +397,12 @@ impl Graph {
       package_reqs: snapshot
         .package_reqs
         .into_iter()
-        .map(|(k, v)| (k, Arc::new(v)))
+        .map(|(k, v)| (k, Rc::new(v)))
         .collect(),
       pending_unresolved_packages: snapshot
         .pending_unresolved_packages
         .into_iter()
-        .map(Arc::new)
+        .map(Rc::new)
         .collect(),
       nodes: Default::default(),
       package_name_versions: Default::default(),
@@ -419,12 +418,12 @@ impl Graph {
         &snapshot.packages,
         &mut created_package_ids,
       );
-      graph.root_packages.insert(Arc::new(id), node_id);
+      graph.root_packages.insert(Rc::new(id), node_id);
     }
     (graph, snapshot.api, snapshot.version_resolver)
   }
 
-  pub fn take_pending_unresolved(&mut self) -> Vec<Arc<NpmPackageNv>> {
+  pub fn take_pending_unresolved(&mut self) -> Vec<Rc<NpmPackageNv>> {
     std::mem::take(&mut self.pending_unresolved_packages)
   }
 
@@ -673,7 +672,7 @@ impl Graph {
 
   #[cfg(debug_assertions)]
   #[allow(unused)]
-  fn output_path(&self, path: &Arc<GraphPath>) {
+  fn output_path(&self, path: &Rc<GraphPath>) {
     eprintln!("-----------");
     self.output_node(path.node_id(), false);
     for path in path.ancestors() {
@@ -732,45 +731,42 @@ impl Graph {
 }
 
 #[derive(Default)]
-struct DepEntryCache(HashMap<Arc<NpmPackageNv>, Arc<Vec<NpmDependencyEntry>>>);
+struct DepEntryCache(HashMap<Rc<NpmPackageNv>, Rc<Vec<NpmDependencyEntry>>>);
 
 impl DepEntryCache {
   pub fn store(
     &mut self,
-    nv: Arc<NpmPackageNv>,
+    nv: Rc<NpmPackageNv>,
     version_info: &NpmPackageVersionInfo,
-  ) -> Result<Arc<Vec<NpmDependencyEntry>>, Box<NpmDependencyEntryError>> {
+  ) -> Result<Rc<Vec<NpmDependencyEntry>>, Box<NpmDependencyEntryError>> {
     debug_assert_eq!(nv.version, version_info.version);
     debug_assert!(!self.0.contains_key(&nv)); // we should not be re-inserting
     let mut deps = version_info.dependencies_as_entries(&nv.name)?;
     // Ensure name alphabetical and then version descending
     // so these are resolved in that order
     deps.sort();
-    let deps = Arc::new(deps);
+    let deps = Rc::new(deps);
     self.0.insert(nv, deps.clone());
     Ok(deps)
   }
 
-  pub fn get(
-    &self,
-    id: &NpmPackageNv,
-  ) -> Option<&Arc<Vec<NpmDependencyEntry>>> {
+  pub fn get(&self, id: &NpmPackageNv) -> Option<&Rc<Vec<NpmDependencyEntry>>> {
     self.0.get(id)
   }
 }
 
 struct UnresolvedOptionalPeer {
   specifier: String,
-  graph_path: Arc<GraphPath>,
+  graph_path: Rc<GraphPath>,
 }
 
 pub struct GraphDependencyResolver<'a> {
   graph: &'a mut Graph,
   api: &'a dyn NpmRegistryApi,
   version_resolver: &'a NpmVersionResolver,
-  pending_unresolved_nodes: VecDeque<Arc<GraphPath>>,
+  pending_unresolved_nodes: VecDeque<Rc<GraphPath>>,
   unresolved_optional_peers:
-    HashMap<Arc<NpmPackageNv>, Vec<UnresolvedOptionalPeer>>,
+    HashMap<Rc<NpmPackageNv>, Vec<UnresolvedOptionalPeer>>,
   dep_entry_cache: DepEntryCache,
 }
 
@@ -851,7 +847,7 @@ impl<'a> GraphDependencyResolver<'a> {
     &mut self,
     entry: &NpmDependencyEntry,
     package_info: &NpmPackageInfo,
-    parent_path: &Arc<GraphPath>,
+    parent_path: &Rc<GraphPath>,
   ) -> Result<NodeId, NpmResolutionError> {
     debug_assert_eq!(entry.kind, NpmDependencyEntryKind::Dep);
     let parent_id = parent_path.node_id();
@@ -896,7 +892,7 @@ impl<'a> GraphDependencyResolver<'a> {
     version_req: &VersionReq,
     package_info: &NpmPackageInfo,
     parent_id: Option<NodeId>,
-  ) -> Result<(Arc<NpmPackageNv>, NodeId), NpmResolutionError> {
+  ) -> Result<(Rc<NpmPackageNv>, NodeId), NpmResolutionError> {
     let info = self.version_resolver.resolve_best_package_version_info(
       version_req,
       package_info,
@@ -908,7 +904,7 @@ impl<'a> GraphDependencyResolver<'a> {
         .iter(),
     )?;
     let resolved_id = ResolvedId {
-      nv: Arc::new(NpmPackageNv {
+      nv: Rc::new(NpmPackageNv {
         name: package_info.name.to_string(),
         version: info.version.clone(),
       }),
@@ -1099,7 +1095,7 @@ impl<'a> GraphDependencyResolver<'a> {
     specifier: &str,
     peer_dep: &NpmDependencyEntry,
     peer_package_info: &NpmPackageInfo,
-    ancestor_path: &Arc<GraphPath>,
+    ancestor_path: &Rc<GraphPath>,
   ) -> Result<Option<NodeId>, NpmResolutionError> {
     debug_assert!(matches!(
       peer_dep.kind,
@@ -1179,7 +1175,7 @@ impl<'a> GraphDependencyResolver<'a> {
 
   fn find_peer_dep_in_node(
     &self,
-    path: &Arc<GraphPath>,
+    path: &Rc<GraphPath>,
     peer_dep: &NpmDependencyEntry,
     peer_package_info: &NpmPackageInfo,
   ) -> Result<Option<(GraphPathNodeOrRoot, NodeId)>, NpmResolutionError> {
@@ -1219,8 +1215,8 @@ impl<'a> GraphDependencyResolver<'a> {
   fn add_peer_deps_to_path(
     &mut self,
     // path from the node above the resolved dep to just above the peer dep
-    path: &[&Arc<GraphPath>],
-    peer_deps: &[(&ResolvedIdPeerDep, Arc<NpmPackageNv>)],
+    path: &[&Rc<GraphPath>],
+    peer_deps: &[(&ResolvedIdPeerDep, Rc<NpmPackageNv>)],
   ) {
     debug_assert!(!path.is_empty());
 
@@ -1301,7 +1297,7 @@ impl<'a> GraphDependencyResolver<'a> {
   fn set_new_peer_dep(
     &mut self,
     // path from the node above the resolved dep to just above the peer dep
-    path: &[&Arc<GraphPath>],
+    path: &[&Rc<GraphPath>],
     peer_dep_parent: GraphPathNodeOrRoot,
     peer_dep_specifier: &str,
     peer_dep_id: NodeId,
@@ -1367,8 +1363,8 @@ impl<'a> GraphDependencyResolver<'a> {
 
   fn add_linked_circular_descendant(
     &mut self,
-    ancestor: &Arc<GraphPath>,
-    descendant: Arc<GraphPath>,
+    ancestor: &Rc<GraphPath>,
+    descendant: Rc<GraphPath>,
   ) {
     let ancestor_node_id = ancestor.node_id();
     let path = descendant.get_path_to_ancestor_exclusive(ancestor_node_id);
@@ -1419,7 +1415,7 @@ impl<'a> GraphDependencyResolver<'a> {
     &self,
     peer_dep: &NpmDependencyEntry,
     peer_package_info: &NpmPackageInfo,
-    children: impl Iterator<Item = (NodeId, &'nv Arc<NpmPackageNv>)>,
+    children: impl Iterator<Item = (NodeId, &'nv Rc<NpmPackageNv>)>,
   ) -> Result<Option<NodeId>, NpmResolutionError> {
     for (child_id, pkg_id) in children {
       if pkg_id.name == peer_dep.name
@@ -1452,7 +1448,7 @@ mod test {
     let mut ids = ResolvedNodeIds::default();
     let node_id = NodeId(0);
     let resolved_id = ResolvedId {
-      nv: Arc::new(NpmPackageNv::from_str("package@1.1.1").unwrap()),
+      nv: Rc::new(NpmPackageNv::from_str("package@1.1.1").unwrap()),
       peer_dependencies: Vec::new(),
     };
     ids.set(node_id, resolved_id.clone());
@@ -1461,7 +1457,7 @@ mod test {
     assert_eq!(ids.get_node_id(&resolved_id), Some(node_id));
 
     let resolved_id_new = ResolvedId {
-      nv: Arc::new(NpmPackageNv::from_str("package@1.1.2").unwrap()),
+      nv: Rc::new(NpmPackageNv::from_str("package@1.1.2").unwrap()),
       peer_dependencies: Vec::new(),
     };
     ids.set(node_id, resolved_id_new.clone());

--- a/src/resolution/snapshot.rs
+++ b/src/resolution/snapshot.rs
@@ -4,6 +4,7 @@ use std::collections::hash_map;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::rc::Rc;
 use std::sync::Arc;
 
 use deno_semver::npm::NpmPackageNv;
@@ -298,7 +299,7 @@ impl NpmResolutionSnapshot {
 
     enum ReqOrNv {
       Req(NpmPackageReq),
-      Nv(Arc<NpmPackageNv>),
+      Nv(Rc<NpmPackageNv>),
     }
 
     let mut top_level_packages = futures::stream::FuturesOrdered::from_iter({


### PR DESCRIPTION
We can remove this now, thanks to Matt's PR adding deno_core::task::spawn.