### PR TITLE
refactor: pkg_id to id

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,7 +206,7 @@ impl std::fmt::Display for NpmPackageCacheFolderId {
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct NpmResolutionPackage {
-  pub pkg_id: NpmPackageId,
+  pub id: NpmPackageId,
   /// The peer dependency resolution can differ for the same
   /// package (name and version) depending on where it is in
   /// the resolution tree. This copy index indicates which
@@ -225,7 +225,7 @@ impl std::fmt::Debug for NpmResolutionPackage {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     // custom debug implementation for deterministic output in the tests
     f.debug_struct("NpmResolutionPackage")
-      .field("pkg_id", &self.pkg_id)
+      .field("pkg_id", &self.id)
       .field("copy_index", &self.copy_index)
       .field("cpu", &self.cpu)
       .field("os", &self.os)
@@ -246,7 +246,7 @@ impl std::fmt::Debug for NpmResolutionPackage {
 impl NpmResolutionPackage {
   pub fn as_serialized(&self) -> SerializedNpmResolutionSnapshotPackage {
     SerializedNpmResolutionSnapshotPackage {
-      pkg_id: self.pkg_id.clone(),
+      id: self.id.clone(),
       cpu: self.cpu.clone(),
       os: self.os.clone(),
       dist: self.dist.clone(),
@@ -257,7 +257,7 @@ impl NpmResolutionPackage {
 
   pub fn get_package_cache_folder_id(&self) -> NpmPackageCacheFolderId {
     NpmPackageCacheFolderId {
-      nv: self.pkg_id.nv.clone(),
+      nv: self.id.nv.clone(),
       copy_index: self.copy_index,
     }
   }

--- a/src/resolution/graph.rs
+++ b/src/resolution/graph.rs
@@ -623,7 +623,7 @@ impl Graph {
         (*pkg_id).clone(),
         NpmResolutionPackage {
           copy_index: copy_index_resolver.resolve(pkg_id),
-          pkg_id: (*pkg_id).clone(),
+          id: (*pkg_id).clone(),
           cpu: version_info.cpu.clone(),
           os: version_info.os.clone(),
           dist: version_info.dist.clone(),
@@ -3822,7 +3822,7 @@ mod test {
       .all_packages_for_every_system()
       .cloned()
       .collect::<Vec<_>>();
-    packages.sort_by(|a, b| a.pkg_id.cmp(&b.pkg_id));
+    packages.sort_by(|a, b| a.id.cmp(&b.id));
     let mut package_reqs = snapshot
       .package_reqs
       .into_iter()
@@ -3838,7 +3838,7 @@ mod test {
     let packages = packages
       .into_iter()
       .map(|pkg| TestNpmResolutionPackage {
-        pkg_id: pkg.pkg_id.as_serialized(),
+        pkg_id: pkg.id.as_serialized(),
         copy_index: pkg.copy_index,
         dependencies: pkg
           .dependencies
@@ -3858,7 +3858,7 @@ mod test {
     let mut packages = snapshot
       .all_system_packages(system_info)
       .into_iter()
-      .map(|p| p.pkg_id.as_serialized())
+      .map(|p| p.id.as_serialized())
       .collect::<Vec<_>>();
     packages.sort();
     packages
@@ -3872,7 +3872,7 @@ mod test {
       snapshot: &NpmResolutionSnapshot,
     ) -> SerializedNpmResolutionSnapshot {
       let mut snapshot = snapshot.as_serialized();
-      snapshot.packages.sort_by(|a, b| a.pkg_id.cmp(&b.pkg_id));
+      snapshot.packages.sort_by(|a, b| a.id.cmp(&b.id));
       snapshot
     }
 


### PR DESCRIPTION
This has annoyed me. The `pkg_` doesn't really ever help with readability.