### PR TITLE
feat: add SerializedNpmResolutionSnapshot.into_valid_unsafe

### DIFF
--- a/src/resolution/snapshot.rs
+++ b/src/resolution/snapshot.rs
@@ -135,6 +135,18 @@ impl SerializedNpmResolutionSnapshot {
 
     Ok(ValidSerializedNpmResolutionSnapshot(self))
   }
+
+  /// Trusts that the serialized snapshot is valid and skips runtime verification
+  /// that is done in `into_valid`.
+  ///
+  /// Note: It will still do the verification in debug.
+  pub fn unsafe_into_valid(self) -> ValidSerializedNpmResolutionSnapshot {
+    if cfg!(debug) {
+      self.into_valid().unwrap()
+    } else {
+      ValidSerializedNpmResolutionSnapshot(self)
+    }
+  }
 }
 
 impl std::fmt::Debug for SerializedNpmResolutionSnapshot {

--- a/src/resolution/snapshot.rs
+++ b/src/resolution/snapshot.rs
@@ -140,7 +140,7 @@ impl SerializedNpmResolutionSnapshot {
   /// that is done in `into_valid`.
   ///
   /// Note: It will still do the verification in debug.
-  pub fn unsafe_into_valid(self) -> ValidSerializedNpmResolutionSnapshot {
+  pub fn into_valid_unsafe(self) -> ValidSerializedNpmResolutionSnapshot {
     if cfg!(debug) {
       self.into_valid().unwrap()
     } else {


### PR DESCRIPTION
In eszip when we deserialize the npm snapshot we already do some steps that ensure it's valid. For this reason, we can just convert directly to a valid serialized snapshot instead of doing the `into_valid()` runtime checks.