### PR TITLE
feat: NpmResolutionSnapshot - Get valid serialized snapshot

### DIFF
--- a/src/resolution/graph.rs
+++ b/src/resolution/graph.rs
@@ -3871,7 +3871,7 @@ mod test {
     fn snapshot_to_serialized(
       snapshot: &NpmResolutionSnapshot,
     ) -> SerializedNpmResolutionSnapshot {
-      let mut snapshot = snapshot.as_serialized();
+      let mut snapshot = snapshot.as_valid_serialized().into_serialized();
       snapshot.packages.sort_by(|a, b| a.id.cmp(&b.id));
       snapshot
     }

--- a/src/resolution/snapshot.rs
+++ b/src/resolution/snapshot.rs
@@ -85,6 +85,16 @@ pub struct ValidSerializedNpmResolutionSnapshot(
   SerializedNpmResolutionSnapshot,
 );
 
+impl ValidSerializedNpmResolutionSnapshot {
+  pub fn as_serialized(&self) -> &SerializedNpmResolutionSnapshot {
+    &self.0
+  }
+
+  pub fn into_serialized(self) -> SerializedNpmResolutionSnapshot {
+    self.0
+  }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SerializedNpmResolutionSnapshotPackage {
   pub id: NpmPackageId,
@@ -248,9 +258,9 @@ impl NpmResolutionSnapshot {
     }
   }
 
-  /// Gets the snapshot as a serialized snapshot.
-  pub fn as_serialized(&self) -> SerializedNpmResolutionSnapshot {
-    SerializedNpmResolutionSnapshot {
+  /// Gets the snapshot as a valid serialized snapshot.
+  pub fn as_valid_serialized(&self) -> ValidSerializedNpmResolutionSnapshot {
+    ValidSerializedNpmResolutionSnapshot(SerializedNpmResolutionSnapshot {
       root_packages: self
         .package_reqs
         .iter()
@@ -264,7 +274,7 @@ impl NpmResolutionSnapshot {
         .values()
         .map(|package| package.as_serialized())
         .collect(),
-    }
+    })
   }
 
   /// Gets if this snapshot is empty.

--- a/src/resolution/snapshot.rs
+++ b/src/resolution/snapshot.rs
@@ -78,7 +78,7 @@ impl NpmPackagesPartitioned {
 
 /// A serialized snapshot that has been verified to be non-corrupt
 /// and valid.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct ValidSerializedNpmResolutionSnapshot(
   // keep private -- once verified the caller
   // shouldn't be able to modify it


### PR DESCRIPTION
We already know the data in the `NpmResolutionSnapshot` is valid, so the `as_serialized()` should actually be `as_valid_serialized()` then we can have some methods on the valid snapshot for converting to a serialized snapshot.