### PR TITLE
refactor: extract pending resolution to separate struct

### DIFF
--- a/src/resolution/graph.rs
+++ b/src/resolution/graph.rs
@@ -333,9 +333,7 @@ pub struct Graph {
 }
 
 impl Graph {
-  pub fn from_snapshot(
-    snapshot: NpmResolutionSnapshot,
-  ) -> (Self, NpmVersionResolver) {
+  pub fn from_snapshot(snapshot: &NpmResolutionSnapshot) -> Self {
     fn get_or_create_graph_node(
       graph: &mut Graph,
       pkg_id: &NpmPackageId,
@@ -395,13 +393,13 @@ impl Graph {
         .collect(),
       package_reqs: snapshot
         .package_reqs
-        .into_iter()
-        .map(|(k, v)| (k, Rc::new(v)))
+        .iter()
+        .map(|(k, v)| (k.clone(), Rc::new(v.clone())))
         .collect(),
       pending_unresolved_packages: snapshot
         .pending_unresolved_packages
-        .into_iter()
-        .map(Rc::new)
+        .iter()
+        .map(|nv| Rc::new(nv.clone()))
         .collect(),
       nodes: Default::default(),
       package_name_versions: Default::default(),
@@ -410,16 +408,16 @@ impl Graph {
     };
     let mut created_package_ids =
       HashMap::with_capacity(snapshot.packages.len());
-    for (id, resolved_id) in snapshot.root_packages {
+    for (id, resolved_id) in &snapshot.root_packages {
       let node_id = get_or_create_graph_node(
         &mut graph,
-        &resolved_id,
+        resolved_id,
         &snapshot.packages,
         &mut created_package_ids,
       );
-      graph.root_packages.insert(Rc::new(id), node_id);
+      graph.root_packages.insert(Rc::new(id.clone()), node_id);
     }
-    (graph, snapshot.version_resolver)
+    graph
   }
 
   pub fn take_pending_unresolved(&mut self) -> Vec<Rc<NpmPackageNv>> {
@@ -559,10 +557,9 @@ impl Graph {
     parent.children.insert(specifier.to_string(), child_id);
   }
 
-  pub async fn into_snapshot(
+  pub async fn into_snapshot<TNpmRegistryApi: NpmRegistryApi>(
     self,
-    api: &dyn NpmRegistryApi,
-    version_resolver: NpmVersionResolver,
+    api: &TNpmRegistryApi,
   ) -> Result<NpmResolutionSnapshot, NpmRegistryPackageInfoLoadError> {
     let packages_to_pkg_ids = self
       .nodes
@@ -640,7 +637,6 @@ impl Graph {
     }
 
     Ok(NpmResolutionSnapshot {
-      version_resolver,
       root_packages: self
         .root_packages
         .into_iter()
@@ -765,9 +761,9 @@ struct UnresolvedOptionalPeer {
   graph_path: Rc<GraphPath>,
 }
 
-pub struct GraphDependencyResolver<'a> {
+pub struct GraphDependencyResolver<'a, TNpmRegistryApi: NpmRegistryApi> {
   graph: &'a mut Graph,
-  api: &'a dyn NpmRegistryApi,
+  api: &'a TNpmRegistryApi,
   version_resolver: &'a NpmVersionResolver,
   pending_unresolved_nodes: VecDeque<Rc<GraphPath>>,
   unresolved_optional_peers:
@@ -775,10 +771,12 @@ pub struct GraphDependencyResolver<'a> {
   dep_entry_cache: DepEntryCache,
 }
 
-impl<'a> GraphDependencyResolver<'a> {
+impl<'a, TNpmRegistryApi: NpmRegistryApi>
+  GraphDependencyResolver<'a, TNpmRegistryApi>
+{
   pub fn new(
     graph: &'a mut Graph,
-    api: &'a dyn NpmRegistryApi,
+    api: &'a TNpmRegistryApi,
     version_resolver: &'a NpmVersionResolver,
   ) -> Self {
     Self {
@@ -1457,7 +1455,6 @@ mod test {
   use pretty_assertions::assert_eq;
 
   use crate::registry::TestNpmRegistryApi;
-  use crate::resolution::NpmResolutionSnapshotCreateOptions;
   use crate::resolution::SerializedNpmResolutionSnapshot;
   use crate::NpmSystemInfo;
 
@@ -3887,12 +3884,8 @@ mod test {
       snapshot
     }
 
-    let snapshot =
-      NpmResolutionSnapshot::new(NpmResolutionSnapshotCreateOptions {
-        snapshot: Default::default(),
-        types_node_version_req: None,
-      });
-    let (mut graph, version_resolver) = Graph::from_snapshot(snapshot);
+    let snapshot = NpmResolutionSnapshot::new(Default::default());
+    let mut graph = Graph::from_snapshot(&snapshot);
     let npm_version_resolver = NpmVersionResolver {
       types_node_version_req: None,
     };
@@ -3907,22 +3900,19 @@ mod test {
     }
 
     resolver.resolve_pending().await.unwrap();
-    let snapshot = graph.into_snapshot(&api, version_resolver).await.unwrap();
+    let snapshot = graph.into_snapshot(&api).await.unwrap();
 
     {
-      let (graph, version_resolver) = Graph::from_snapshot(snapshot.clone());
-      let new_snapshot =
-        graph.into_snapshot(&api, version_resolver).await.unwrap();
+      let graph = Graph::from_snapshot(&snapshot);
+      let new_snapshot = graph.into_snapshot(&api).await.unwrap();
       assert_eq!(
         snapshot_to_serialized(&snapshot),
         snapshot_to_serialized(&new_snapshot),
         "recreated snapshot should be the same"
       );
       // create one again from the new snapshot
-      let (graph, version_resolver) =
-        Graph::from_snapshot(new_snapshot.clone());
-      let new_snapshot2 =
-        graph.into_snapshot(&api, version_resolver).await.unwrap();
+      let graph = Graph::from_snapshot(&new_snapshot);
+      let new_snapshot2 = graph.into_snapshot(&api).await.unwrap();
       assert_eq!(
         snapshot_to_serialized(&snapshot),
         snapshot_to_serialized(&new_snapshot2),

--- a/src/resolution/mod.rs
+++ b/src/resolution/mod.rs
@@ -7,7 +7,7 @@ pub use common::NpmPackageVersionResolutionError;
 pub use graph::NpmResolutionError;
 pub use snapshot::NpmPackagesPartitioned;
 pub use snapshot::NpmResolutionSnapshot;
-pub use snapshot::NpmResolutionSnapshotCreateOptions;
+pub use snapshot::NpmResolutionSnapshotPendingResolver;
 pub use snapshot::PackageIdNotFoundError;
 pub use snapshot::PackageNotFoundFromReferrerError;
 pub use snapshot::PackageNvNotFoundError;

--- a/src/resolution/mod.rs
+++ b/src/resolution/mod.rs
@@ -8,6 +8,7 @@ pub use graph::NpmResolutionError;
 pub use snapshot::NpmPackagesPartitioned;
 pub use snapshot::NpmResolutionSnapshot;
 pub use snapshot::NpmResolutionSnapshotPendingResolver;
+pub use snapshot::NpmResolutionSnapshotPendingResolverOptions;
 pub use snapshot::PackageIdNotFoundError;
 pub use snapshot::PackageNotFoundFromReferrerError;
 pub use snapshot::PackageNvNotFoundError;

--- a/src/resolution/snapshot.rs
+++ b/src/resolution/snapshot.rs
@@ -684,7 +684,7 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
   /// a package.json while the pending are specifiers found in the graph)
   pub async fn resolve_pending(
     &self,
-    snapshot: &NpmResolutionSnapshot,
+    snapshot: NpmResolutionSnapshot,
     package_reqs: &[NpmPackageReq],
   ) -> Result<NpmResolutionSnapshot, NpmResolutionError> {
     // convert the snapshot to a traversable graph

--- a/src/resolution/snapshot.rs
+++ b/src/resolution/snapshot.rs
@@ -172,16 +172,8 @@ impl std::fmt::Debug for SerializedNpmResolutionSnapshot {
   }
 }
 
-pub struct NpmResolutionSnapshotCreateOptions {
-  pub snapshot: ValidSerializedNpmResolutionSnapshot,
-  /// Known good version requirement to use for the `@types/node` package
-  /// when the version is unspecified or "latest".
-  pub types_node_version_req: Option<VersionReq>,
-}
-
 #[derive(Clone)]
 pub struct NpmResolutionSnapshot {
-  pub(super) version_resolver: NpmVersionResolver,
   /// The unique package requirements map to a single npm package name and version.
   pub(super) package_reqs: HashMap<NpmPackageReq, NpmPackageNv>,
   // Each root level npm package name and version maps to an exact npm package node id.
@@ -194,8 +186,8 @@ pub struct NpmResolutionSnapshot {
 }
 
 impl NpmResolutionSnapshot {
-  pub fn new(options: NpmResolutionSnapshotCreateOptions) -> Self {
-    let snapshot = options.snapshot.0;
+  pub fn new(snapshot: ValidSerializedNpmResolutionSnapshot) -> Self {
+    let snapshot = snapshot.0;
     let mut package_reqs =
       HashMap::<NpmPackageReq, NpmPackageNv>::with_capacity(
         snapshot.root_packages.len(),
@@ -243,9 +235,6 @@ impl NpmResolutionSnapshot {
     }
 
     Self {
-      version_resolver: NpmVersionResolver {
-        types_node_version_req: options.types_node_version_req,
-      },
       package_reqs,
       root_packages,
       packages_by_name,
@@ -346,79 +335,12 @@ impl NpmResolutionSnapshot {
     // this is `into_empty()` instead of something like `clear()` in order
     // to reduce the chance of a mistake forgetting to clear a collection
     Self {
-      version_resolver: self.version_resolver,
       package_reqs: Default::default(),
       root_packages: Default::default(),
       packages_by_name: Default::default(),
       packages: Default::default(),
       pending_unresolved_packages: Default::default(),
     }
-  }
-
-  /// Resolves any pending packages in the snapshot along with the provided
-  /// package requirements (in the CLI, these are package requirements from
-  /// a package.json while the pending are specifiers found in the graph)
-  pub async fn resolve_pending(
-    self,
-    api: &dyn NpmRegistryApi,
-    package_reqs: &[NpmPackageReq],
-  ) -> Result<Self, NpmResolutionError> {
-    // convert the snapshot to a traversable graph
-    let (mut graph, version_resolver) = Graph::from_snapshot(self);
-    let pending_unresolved = graph.take_pending_unresolved();
-
-    let package_reqs =
-      package_reqs.iter().filter(|r| !graph.has_package_req(r));
-    let pending_unresolved = pending_unresolved
-      .into_iter()
-      .filter(|p| !graph.has_root_package(p));
-
-    enum ReqOrNv<'a> {
-      Req(&'a NpmPackageReq),
-      Nv(Rc<NpmPackageNv>),
-    }
-
-    let mut top_level_packages = futures::stream::FuturesOrdered::from_iter({
-      let api = &api;
-      package_reqs
-        .map(|req| {
-          Either::Left(async {
-            let info = api.package_info(&req.name).await?;
-            Result::<_, NpmRegistryPackageInfoLoadError>::Ok((
-              ReqOrNv::Req(req),
-              info,
-            ))
-          })
-        })
-        .chain(pending_unresolved.map(|nv| {
-          Either::Right(async {
-            let info = api.package_info(&nv.name).await?;
-            Ok((ReqOrNv::Nv(nv), info))
-          })
-        }))
-    });
-
-    // go over the top level package names first (npm package reqs and pending unresolved),
-    // then down the tree one level at a time through all the branches
-    let mut resolver =
-      GraphDependencyResolver::new(&mut graph, api, &version_resolver);
-
-    // The package reqs and ids should already be sorted
-    // in the order they should be resolved in.
-    while let Some(result) = top_level_packages.next().await {
-      let (req_or_nv, info) = result?;
-      match req_or_nv {
-        ReqOrNv::Req(req) => resolver.add_package_req(req, &info)?,
-        ReqOrNv::Nv(nv) => resolver.add_root_package(&nv, &info)?,
-      }
-    }
-    drop(top_level_packages); // stop borrow of api
-
-    resolver.resolve_pending().await?;
-
-    let snapshot = graph.into_snapshot(api, version_resolver).await?;
-    debug_assert!(!snapshot.has_pending());
-    Ok(snapshot)
   }
 
   /// Resolve a package from a package requirement.
@@ -620,41 +542,6 @@ impl NpmResolutionSnapshot {
     maybe_best_id.cloned()
   }
 
-  pub fn resolve_package_req_as_pending(
-    &mut self,
-    pkg_req: &NpmPackageReq,
-    package_info: &NpmPackageInfo,
-  ) -> Result<NpmPackageNv, NpmPackageVersionResolutionError> {
-    let version_req =
-      pkg_req.version_req.as_ref().unwrap_or(&*LATEST_VERSION_REQ);
-    let version_info = match self.packages_by_name.get(&package_info.name) {
-      Some(existing_versions) => {
-        self.version_resolver.resolve_best_package_version_info(
-          version_req,
-          package_info,
-          existing_versions.iter().map(|p| &p.nv.version),
-        )?
-      }
-      None => self.version_resolver.resolve_best_package_version_info(
-        version_req,
-        package_info,
-        Vec::new().iter(),
-      )?,
-    };
-    let nv = NpmPackageNv {
-      name: package_info.name.to_string(),
-      version: version_info.version.clone(),
-    };
-    debug!(
-      "Resolved {}@{} to {}",
-      pkg_req.name,
-      version_req.version_text(),
-      nv,
-    );
-    self.add_pending_pkg(pkg_req.clone(), nv.clone());
-    Ok(nv)
-  }
-
   fn add_pending_pkg(&mut self, pkg_req: NpmPackageReq, nv: NpmPackageNv) {
     self.package_reqs.insert(pkg_req, nv.clone());
     let packages_with_name =
@@ -720,6 +607,145 @@ impl SnapshotPackageCopyIndexResolver {
       self.packages_to_copy_index.insert(node_id.clone(), index);
       index
     }
+  }
+}
+
+pub struct NpmResolutionSnapshotPendingResolverOptions<
+  'a,
+  TNpmRegistryApi: NpmRegistryApi,
+> {
+  pub api: &'a TNpmRegistryApi,
+  /// Known good version requirement to use for the `@types/node` package
+  /// when the version is unspecified or "latest".
+  pub types_node_version_req: Option<VersionReq>,
+}
+
+/// Resolves pending packages in the npm snapshot.
+pub struct NpmResolutionSnapshotPendingResolver<
+  'a,
+  TNpmRegistryApi: NpmRegistryApi,
+> {
+  version_resolver: NpmVersionResolver,
+  api: &'a TNpmRegistryApi,
+}
+
+impl<'a, TNpmRegistryApi: NpmRegistryApi>
+  NpmResolutionSnapshotPendingResolver<'a, TNpmRegistryApi>
+{
+  pub fn new(
+    options: NpmResolutionSnapshotPendingResolverOptions<'a, TNpmRegistryApi>,
+  ) -> Self {
+    Self {
+      api: options.api,
+      version_resolver: NpmVersionResolver {
+        types_node_version_req: options.types_node_version_req,
+      },
+    }
+  }
+
+  pub fn resolve_package_req_as_pending(
+    &self,
+    snapshot: &mut NpmResolutionSnapshot,
+    pkg_req: &NpmPackageReq,
+    package_info: &NpmPackageInfo,
+  ) -> Result<NpmPackageNv, NpmPackageVersionResolutionError> {
+    let version_req =
+      pkg_req.version_req.as_ref().unwrap_or(&*LATEST_VERSION_REQ);
+    let version_info = match snapshot.packages_by_name.get(&package_info.name) {
+      Some(existing_versions) => {
+        self.version_resolver.resolve_best_package_version_info(
+          version_req,
+          package_info,
+          existing_versions.iter().map(|p| &p.nv.version),
+        )?
+      }
+      None => self.version_resolver.resolve_best_package_version_info(
+        version_req,
+        package_info,
+        Vec::new().iter(),
+      )?,
+    };
+    let nv = NpmPackageNv {
+      name: package_info.name.to_string(),
+      version: version_info.version.clone(),
+    };
+    debug!(
+      "Resolved {}@{} to {}",
+      pkg_req.name,
+      version_req.version_text(),
+      nv,
+    );
+    snapshot.add_pending_pkg(pkg_req.clone(), nv.clone());
+    Ok(nv)
+  }
+
+  /// Resolves any pending packages in the snapshot along with the provided
+  /// package requirements (in the CLI, these are package requirements from
+  /// a package.json while the pending are specifiers found in the graph)
+  pub async fn resolve_pending(
+    &self,
+    snapshot: &NpmResolutionSnapshot,
+    package_reqs: &[NpmPackageReq],
+  ) -> Result<NpmResolutionSnapshot, NpmResolutionError> {
+    // convert the snapshot to a traversable graph
+    let mut graph = Graph::from_snapshot(snapshot);
+    let pending_unresolved = graph.take_pending_unresolved();
+
+    let package_reqs =
+      package_reqs.iter().filter(|r| !graph.has_package_req(r));
+    let pending_unresolved = pending_unresolved
+      .into_iter()
+      .filter(|p| !graph.has_root_package(p));
+
+    enum ReqOrNv<'a> {
+      Req(&'a NpmPackageReq),
+      Nv(Rc<NpmPackageNv>),
+    }
+
+    let mut top_level_packages = futures::stream::FuturesOrdered::from_iter({
+      let api = &self.api;
+      package_reqs
+        .map(|req| {
+          Either::Left(async {
+            let info = api.package_info(&req.name).await?;
+            Result::<_, NpmRegistryPackageInfoLoadError>::Ok((
+              ReqOrNv::Req(req),
+              info,
+            ))
+          })
+        })
+        .chain(pending_unresolved.map(|nv| {
+          Either::Right(async {
+            let info = api.package_info(&nv.name).await?;
+            Ok((ReqOrNv::Nv(nv), info))
+          })
+        }))
+    });
+
+    // go over the top level package names first (npm package reqs and pending unresolved),
+    // then down the tree one level at a time through all the branches
+    let mut resolver = GraphDependencyResolver::new(
+      &mut graph,
+      self.api,
+      &self.version_resolver,
+    );
+
+    // The package reqs and ids should already be sorted
+    // in the order they should be resolved in.
+    while let Some(result) = top_level_packages.next().await {
+      let (req_or_nv, info) = result?;
+      match req_or_nv {
+        ReqOrNv::Req(req) => resolver.add_package_req(req, &info)?,
+        ReqOrNv::Nv(nv) => resolver.add_root_package(&nv, &info)?,
+      }
+    }
+    drop(top_level_packages); // stop borrow of api
+
+    resolver.resolve_pending().await?;
+
+    let snapshot = graph.into_snapshot(self.api).await?;
+    debug_assert!(!snapshot.has_pending());
+    Ok(snapshot)
   }
 }
 
@@ -836,11 +862,7 @@ mod tests {
     }
     .into_valid()
     .unwrap();
-    let snapshot =
-      NpmResolutionSnapshot::new(NpmResolutionSnapshotCreateOptions {
-        snapshot: original_serialized.clone(),
-        types_node_version_req: None,
-      });
+    let snapshot = NpmResolutionSnapshot::new(original_serialized.clone());
     // test providing a matching system
     {
       let mut actual = snapshot


### PR DESCRIPTION
Continuation of #17. Removes the `version_resolver` from the NpmResolutionSnapshot.