### PR TITLE
fix: resolve a version requirement to the latest dist tag if it matches

### DIFF
--- a/src/resolution/common.rs
+++ b/src/resolution/common.rs
@@ -84,6 +84,7 @@ impl NpmVersionResolver {
       self.tag_to_version_info(info, tag)
       // When the version is *, if there is a latest tag, use it directly.
       // When the latest tag satisfies the version requirement, use it directly.
+      // https://github.com/npm/npm-pick-manifest/blob/67508da8e21f7317e3159765006da0d6a0a61f84/lib/index.js#L125
       // No need to care about @types/node here, because it'll be handled specially below.
     } else if info.dist_tags.contains_key("latest")
       && info.name != "@types/node"

--- a/src/resolution/common.rs
+++ b/src/resolution/common.rs
@@ -380,4 +380,47 @@ mod test {
     );
     assert_eq!(result.unwrap().version.to_string(), "0.1.0-alpha.1");
   }
+
+  #[test]
+  #[should_panic]
+  fn test_latest_tag_version_req_panic() {
+    let package_req = PackageReq::from_str("some-pkg@^0.1.0-alpha.1").unwrap();
+    let package_info = NpmPackageInfo {
+      name: "some-pkg".to_string(),
+      versions: HashMap::from([
+        (
+          Version::parse_from_npm("0.1.0-alpha.1").unwrap(),
+          NpmPackageVersionInfo {
+            version: Version::parse_from_npm("0.1.0-alpha.1").unwrap(),
+            ..Default::default()
+          },
+        ),
+        (
+          Version::parse_from_npm("0.1.0-beta.1").unwrap(),
+          NpmPackageVersionInfo {
+            version: Version::parse_from_npm("0.1.0-beta.1").unwrap(),
+            ..Default::default()
+          },
+        ),
+      ]),
+      dist_tags: HashMap::from([
+        (
+          "latest".to_string(),
+          Version::parse_from_npm("0.1.0-alpha.1").unwrap(),
+        ),
+        (
+          "dev".to_string(),
+          Version::parse_from_npm("0.1.0-beta.1").unwrap(),
+        ),
+      ]),
+    };
+    let resolver = NpmVersionResolver {
+      types_node_version_req: None,
+    };
+    let result = resolver.get_resolved_package_version_and_info(
+      &package_req.version_req,
+      &package_info,
+    );
+    assert_eq!(result.unwrap().version.to_string(), "0.1.0-beta.1");
+  }
 }

--- a/src/resolution/common.rs
+++ b/src/resolution/common.rs
@@ -338,4 +338,46 @@ mod test {
     );
     assert_eq!(result.unwrap().version.to_string(), "1.0.0-rc.1");
   }
+
+  #[test]
+  fn test_latest_tag_version_req() {
+    let package_req = PackageReq::from_str("some-pkg@^0.1.0-alpha.1").unwrap();
+    let package_info = NpmPackageInfo {
+      name: "some-pkg".to_string(),
+      versions: HashMap::from([
+        (
+          Version::parse_from_npm("0.1.0-alpha.1").unwrap(),
+          NpmPackageVersionInfo {
+            version: Version::parse_from_npm("0.1.0-alpha.1").unwrap(),
+            ..Default::default()
+          },
+        ),
+        (
+          Version::parse_from_npm("0.1.0-beta.1").unwrap(),
+          NpmPackageVersionInfo {
+            version: Version::parse_from_npm("0.1.0-beta.1").unwrap(),
+            ..Default::default()
+          },
+        ),
+      ]),
+      dist_tags: HashMap::from([
+        (
+          "latest".to_string(),
+          Version::parse_from_npm("0.1.0-alpha.1").unwrap(),
+        ),
+        (
+          "dev".to_string(),
+          Version::parse_from_npm("0.1.0-beta.1").unwrap(),
+        ),
+      ]),
+    };
+    let resolver = NpmVersionResolver {
+      types_node_version_req: None,
+    };
+    let result = resolver.get_resolved_package_version_and_info(
+      &package_req.version_req,
+      &package_info,
+    );
+    assert_eq!(result.unwrap().version.to_string(), "0.1.0-alpha.1");
+  }
 }

--- a/src/resolution/common.rs
+++ b/src/resolution/common.rs
@@ -89,9 +89,12 @@ impl NpmVersionResolver {
     } else if info.dist_tags.contains_key("latest")
       && info.name != "@types/node"
       && (*version_req == *WILDCARD_VERSION_REQ
-        || info.dist_tags.get("latest").and_then(|version| {
-          self.version_req_satisfies(version_req, version, info).ok()
-        }) == Some(true))
+        || info
+          .dist_tags
+          .get("latest")
+          .map(|version| self.version_req_satisfies(version_req, version, info))
+          .transpose()?
+          .unwrap_or_default())
     {
       self.tag_to_version_info(info, "latest")
     } else {

--- a/src/resolution/common.rs
+++ b/src/resolution/common.rs
@@ -83,6 +83,7 @@ impl NpmVersionResolver {
     if let Some(tag) = version_req.tag() {
       self.tag_to_version_info(info, tag)
       // When the version is *, if there is a latest tag, use it directly.
+      // When the latest tag satisfies the version requirement, use it directly.
       // No need to care about @types/node here, because it'll be handled specially below.
     } else if info.dist_tags.contains_key("latest")
       && info.name != "@types/node"

--- a/src/resolution/common.rs
+++ b/src/resolution/common.rs
@@ -341,7 +341,7 @@ mod test {
 
   #[test]
   fn test_latest_tag_version_req() {
-    let package_req = PackageReq::from_str("some-pkg@^0.1.0-alpha.1").unwrap();
+    let package_req = PackageReq::from_str("some-pkg@^0.1.0-alpha.2").unwrap();
     let package_info = NpmPackageInfo {
       name: "some-pkg".to_string(),
       versions: HashMap::from([
@@ -353,45 +353,9 @@ mod test {
           },
         ),
         (
-          Version::parse_from_npm("0.1.0-beta.1").unwrap(),
+          Version::parse_from_npm("0.1.0-alpha.2").unwrap(),
           NpmPackageVersionInfo {
-            version: Version::parse_from_npm("0.1.0-beta.1").unwrap(),
-            ..Default::default()
-          },
-        ),
-      ]),
-      dist_tags: HashMap::from([
-        (
-          "latest".to_string(),
-          Version::parse_from_npm("0.1.0-alpha.1").unwrap(),
-        ),
-        (
-          "dev".to_string(),
-          Version::parse_from_npm("0.1.0-beta.1").unwrap(),
-        ),
-      ]),
-    };
-    let resolver = NpmVersionResolver {
-      types_node_version_req: None,
-    };
-    let result = resolver.get_resolved_package_version_and_info(
-      &package_req.version_req,
-      &package_info,
-    );
-    assert_eq!(result.unwrap().version.to_string(), "0.1.0-alpha.1");
-  }
-
-  #[test]
-  #[should_panic]
-  fn test_latest_tag_version_req_panic() {
-    let package_req = PackageReq::from_str("some-pkg@^0.1.0-alpha.1").unwrap();
-    let package_info = NpmPackageInfo {
-      name: "some-pkg".to_string(),
-      versions: HashMap::from([
-        (
-          Version::parse_from_npm("0.1.0-alpha.1").unwrap(),
-          NpmPackageVersionInfo {
-            version: Version::parse_from_npm("0.1.0-alpha.1").unwrap(),
+            version: Version::parse_from_npm("0.1.0-alpha.2").unwrap(),
             ..Default::default()
           },
         ),
@@ -402,15 +366,22 @@ mod test {
             ..Default::default()
           },
         ),
+        (
+          Version::parse_from_npm("0.1.0-beta.2").unwrap(),
+          NpmPackageVersionInfo {
+            version: Version::parse_from_npm("0.1.0-beta.2").unwrap(),
+            ..Default::default()
+          },
+        ),
       ]),
       dist_tags: HashMap::from([
         (
           "latest".to_string(),
-          Version::parse_from_npm("0.1.0-alpha.1").unwrap(),
+          Version::parse_from_npm("0.1.0-alpha.2").unwrap(),
         ),
         (
           "dev".to_string(),
-          Version::parse_from_npm("0.1.0-beta.1").unwrap(),
+          Version::parse_from_npm("0.1.0-beta.2").unwrap(),
         ),
       ]),
     };
@@ -421,6 +392,10 @@ mod test {
       &package_req.version_req,
       &package_info,
     );
-    assert_eq!(result.unwrap().version.to_string(), "0.1.0-beta.1");
+    assert_eq!(
+      result.as_ref().unwrap().version.to_string(),
+      "0.1.0-alpha.2"
+    );
+    assert_ne!(result.as_ref().unwrap().version.to_string(), "0.1.0-beta.2");
   }
 }

--- a/src/resolution/common.rs
+++ b/src/resolution/common.rs
@@ -84,9 +84,12 @@ impl NpmVersionResolver {
       self.tag_to_version_info(info, tag)
       // When the version is *, if there is a latest tag, use it directly.
       // No need to care about @types/node here, because it'll be handled specially below.
-    } else if *version_req == *WILDCARD_VERSION_REQ
-      && info.dist_tags.contains_key("latest")
+    } else if info.dist_tags.contains_key("latest")
       && info.name != "@types/node"
+      && (*version_req == *WILDCARD_VERSION_REQ
+        || info.dist_tags.get("latest").and_then(|version| {
+          self.version_req_satisfies(version_req, version, info).ok()
+        }) == Some(true))
     {
       self.tag_to_version_info(info, "latest")
     } else {


### PR DESCRIPTION
Closes #36

Adds logic to return the `latest` tagged version if it is present and satisfies the version requirement.