### PR TITLE
refactor: remove concept of pending resolution

### DIFF
--- a/src/registry.rs
+++ b/src/registry.rs
@@ -329,14 +329,12 @@ pub enum NpmRegistryPackageInfoLoadError {
   LoadError(#[from] Arc<anyhow::Error>),
 }
 
-// todo(dsherret): remove `Sync` here and use `async_trait(?Send)` once the LSP
-// in the Deno repo is no longer `Send` (https://github.com/denoland/deno/issues/18079)
 /// A trait for getting package information from the npm registry.
 ///
 /// An implementer may want to override the default implementation of
 /// [`mark_force_reload`] method if it has a cache mechanism.
-#[async_trait]
-pub trait NpmRegistryApi: Sync + Send {
+#[async_trait(?Send)]
+pub trait NpmRegistryApi {
   /// Gets the package information from the npm registry.
   ///
   /// Note: The implementer should handle requests for the same npm
@@ -509,7 +507,7 @@ impl TestNpmRegistryApi {
   }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl NpmRegistryApi for TestNpmRegistryApi {
   async fn package_info(
     &self,

--- a/src/resolution/mod.rs
+++ b/src/resolution/mod.rs
@@ -10,6 +10,7 @@ pub use common::NpmPackageVersionResolutionError;
 pub use graph::NpmResolutionError;
 pub use snapshot::incomplete_snapshot_from_lockfile;
 pub use snapshot::snapshot_from_lockfile;
+pub use snapshot::AddPkgReqsResult;
 pub use snapshot::NpmPackagesPartitioned;
 pub use snapshot::NpmResolutionSnapshot;
 pub use snapshot::NpmResolutionSnapshotPendingResolver;

--- a/src/resolution/snapshot.rs
+++ b/src/resolution/snapshot.rs
@@ -654,9 +654,7 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
     }
   }
 
-  /// Resolves any pending packages in the snapshot along with the provided
-  /// package requirements (in the CLI, these are package requirements from
-  /// a package.json while the pending are specifiers found in the graph)
+  /// Resolves the provided package requirements.
   pub async fn add_pkg_reqs(
     &self,
     snapshot: NpmResolutionSnapshot,


### PR DESCRIPTION
No longer necessary because we resolve from deno_graph in a batch. This will simplify things.

I'll integrate this in the CLI before marking this as ready.