### PR TITLE
feat: event for a resolved package nv

### DIFF
--- a/src/registry.rs
+++ b/src/registry.rs
@@ -346,6 +346,12 @@ pub trait NpmRegistryApi {
     name: &str,
   ) -> Result<Arc<NpmPackageInfo>, NpmRegistryPackageInfoLoadError>;
 
+  /// Optional method an implementer can use to start downloading a package
+  /// name and version and doing a basic setup of the node_modules directory.
+  fn preload_package_nv(&self, _nv: &PackageNv) {
+    // do nothing by default
+  }
+
   /// Marks that new requests for package information should retrieve it
   /// from the npm registry
   ///

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -348,7 +348,14 @@ pub trait NpmRegistryApi {
 
   /// Optional method an implementer can use to start downloading a package
   /// name and version and doing a basic setup of the node_modules directory.
-  fn preload_package_nv(&self, _nv: &PackageNv) {
+  ///
+  /// deno_npm will call this method indistriminately for every package nv it sees.
+  /// It is up to the implementer to not do extra work.
+  fn preload_package_nv(
+    &self,
+    _nv: &PackageNv,
+    _dist: &NpmPackageVersionDistInfo,
+  ) {
     // do nothing by default
   }
 

--- a/src/resolution/graph.rs
+++ b/src/resolution/graph.rs
@@ -858,7 +858,6 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
     // just ignore adding these as dependencies because this is likely a mistake
     // in the package.
     if child_id != parent_id {
-      self.api.preload_package_nv(&child_nv);
       let maybe_ancestor = parent_path.find_ancestor(&child_nv);
       if let Some(ancestor) = &maybe_ancestor {
         child_id = ancestor.node_id();
@@ -934,6 +933,9 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
       version_req.version_text(),
       pkg_nv.to_string(),
     );
+
+    // fire off an event to start downloading this nv
+    self.api.preload_package_nv(&pkg_nv, &info.dist);
 
     Ok((pkg_nv, node_id))
   }

--- a/src/resolution/graph.rs
+++ b/src/resolution/graph.rs
@@ -858,6 +858,7 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
     // just ignore adding these as dependencies because this is likely a mistake
     // in the package.
     if child_id != parent_id {
+      self.api.preload_package_nv(&child_nv);
       let maybe_ancestor = parent_path.find_ancestor(&child_nv);
       if let Some(ancestor) = &maybe_ancestor {
         child_id = ancestor.node_id();

--- a/src/resolution/snapshot.rs
+++ b/src/resolution/snapshot.rs
@@ -953,6 +953,7 @@ pub async fn snapshot_from_lockfile<'a>(
             );
           }
         }
+        api.preload_package_nv(&snapshot_package.id.nv);
         packages.push(SerializedNpmResolutionSnapshotPackage {
           id: snapshot_package.id.clone(),
           dependencies: snapshot_package.dependencies.clone(),

--- a/src/resolution/snapshot.rs
+++ b/src/resolution/snapshot.rs
@@ -953,7 +953,10 @@ pub async fn snapshot_from_lockfile<'a>(
             );
           }
         }
-        api.preload_package_nv(&snapshot_package.id.nv);
+
+        // fire off an event to start downloading this nv
+        api.preload_package_nv(&snapshot_package.id.nv, &version_info.dist);
+
         packages.push(SerializedNpmResolutionSnapshotPackage {
           id: snapshot_package.id.clone(),
           dependencies: snapshot_package.dependencies.clone(),


### PR DESCRIPTION
We can use this to immediately start downloading package tarballs and setting up the node_modules directory.

We can't send the package id or folder id here because we don't know that until the end of resolution, but that's fine because this allows us to start downloading and extracting the tarball to the global cache as well as setting up the non-copy folder at `node_modules/.deno/<folder-id>/<package-name>/` where `<folder-id>` is just the package nv (folder-id with an index of `0`).

Closes #24