### PR TITLE
fix: Don't error out on non-existent optional peer dependency

### DIFF
--- a/src/registry.rs
+++ b/src/registry.rs
@@ -534,12 +534,11 @@ impl NpmRegistryApi for TestNpmRegistryApi {
     name: &str,
   ) -> Result<Arc<NpmPackageInfo>, NpmRegistryPackageInfoLoadError> {
     let infos = self.package_infos.borrow();
-    Ok(Arc::new(
-      infos
-        .get(name)
-        .cloned()
-        .unwrap_or_else(|| panic!("Not found: {name}")),
-    ))
+    Ok(Arc::new(infos.get(name).cloned().ok_or_else(|| {
+      NpmRegistryPackageInfoLoadError::PackageNotExists {
+        package_name: name.into(),
+      }
+    })?))
   }
 }
 

--- a/src/resolution/graph.rs
+++ b/src/resolution/graph.rs
@@ -3904,6 +3904,31 @@ mod test {
     }
   }
 
+  #[tokio::test]
+  async fn non_existent_optional_peer_dep() {
+    let api = TestNpmRegistryApi::default();
+    api.ensure_package_version("package-a", "1.0.0");
+    api.ensure_package_version("package-b", "1.0.0");
+    api.add_optional_peer_dependency(
+      ("package-b", "1.0.0"),
+      ("package-non-existent", "*"),
+    );
+    api.add_dependency(("package-a", "1.0.0"), ("package-b", "*"));
+    let snapshot =
+      run_resolver_and_get_snapshot(api, vec!["package-a@1.0.0"]).await;
+    let packages = package_names_with_info(
+      &snapshot,
+      &NpmSystemInfo {
+        os: "darwin".to_string(),
+        cpu: "x86_64".to_string(),
+      },
+    );
+    assert_eq!(
+      packages,
+      vec!["package-a@1.0.0".to_string(), "package-b@1.0.0".to_string(),]
+    );
+  }
+
   #[derive(Debug, Clone, PartialEq, Eq)]
   struct TestNpmResolutionPackage {
     pub pkg_id: String,


### PR DESCRIPTION
As suggested in https://github.com/denoland/deno/issues/25648#issuecomment-2353962760