### PR TITLE
chore: minimal reproduction solver - output folder for local private registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/
 /target
+.bench-reg

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,6 +180,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "deno_error"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,6 +243,7 @@ dependencies = [
  "deno_semver",
  "divan",
  "futures",
+ "hex",
  "indexmap",
  "log",
  "monch",
@@ -222,6 +251,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror",
  "tokio",
  "url",
@@ -249,6 +279,16 @@ name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "displaydoc"
@@ -446,6 +486,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,6 +542,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hipstr"
@@ -1241,6 +1297,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1503,6 +1570,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1542,6 +1615,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,10 @@ capacity_builder = "0.5.0"
 
 [dev-dependencies]
 divan = "0.1.17"
+hex = "0.4.3"
 pretty_assertions = "1.0.0"
 reqwest = "0.12.9"
+sha2 = "0.10.8"
 tokio = { version = "1.27.0", features = ["full"] }
 
 [profile.release-with-debug]

--- a/examples/min_repro_solver.rs
+++ b/examples/min_repro_solver.rs
@@ -20,7 +20,7 @@ use reqwest::StatusCode;
 ///
 /// 1. Provide your package requirements below.
 /// 2. Update the condition saying what the bug is.
-/// 3. Run `cargo run --example minimal_repro_solver`
+/// 3. Run `cargo run --example min_repro_solver`
 ///
 /// This will output some test code that you can use in order to have
 /// a small reproduction of the bug.

--- a/examples/minimal_repro_solver.rs
+++ b/examples/minimal_repro_solver.rs
@@ -20,16 +20,32 @@ use reqwest::StatusCode;
 ///
 /// 1. Provide your package requirements below.
 /// 2. Update the condition saying what the bug is.
-/// 3. Run `cargo run --example minimal_dep_repro`
+/// 3. Run `cargo run --example minimal_repro_solver`
 ///
 /// This will output some test code that you can use in order to have
 /// a small reproduction of the bug.
+///
+/// Additionally, it will populate the `.bench-reg` folder which allows
+/// running a custom npm registry locally via:
+///
+/// ```sh
+/// deno run --allow-net --allow-read=. --allow-write=. jsr:@david/bench-registry@0.3.2/cli --cached-only
+/// ```
+///
+/// Then do `deno clean ; pnpm cache delete`, create an `.npmrc` with:
+///
+/// ```ini
+/// registry=http://localhost:8000/npm/
+/// ```
+///
+/// ...then a package.json with the package requirements below, and you can
+/// compare the reproduction in other package managers.
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
   let mut solver =
     MinimalReproductionSolver::new(&["@aws-cdk/aws-ecs"], |snapshot| {
       snapshot.all_packages_for_every_system().any(|s| {
-        s.id.as_serialized().chars().filter(|c| *c == '_').count() > 20
+        s.id.as_serialized().chars().filter(|c| *c == '_').count() > 200
       })
     })
     .await;
@@ -45,6 +61,7 @@ async fn main() {
   eprintln!("===========================");
   let test_code = solver.get_test_code();
   println!("{}", test_code);
+  solver.output_bench_registry_folder();
 }
 
 struct MinimalReproductionSolver {
@@ -223,6 +240,41 @@ impl MinimalReproductionSolver {
 
     text
   }
+
+  /// Output a .bench-reg folder so that the output can be compared
+  /// with other package managers when using: https://jsr.io/@david/bench-registry@0.2.0
+  fn output_bench_registry_folder(&self) {
+    let package_infos = self.api.get_all_package_infos();
+    let nvs = self.current_nvs();
+    let bench_reg_folder = PathBuf::from(".bench-reg");
+    std::fs::create_dir_all(&bench_reg_folder).unwrap();
+    // trim down the package infos to only contain the found nvs
+    for mut package_info in package_infos {
+      let keys_to_remove = package_info
+        .versions
+        .keys()
+        .filter(|&v| {
+          let nv = PackageNv {
+            name: package_info.name.clone(),
+            version: (v).clone(),
+          };
+          !nvs.contains(&nv)
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+      for key in &keys_to_remove {
+        package_info.versions.remove(key);
+      }
+      let url = packument_url(&package_info.name);
+      let file_path = bench_reg_folder.join(sha256_hex(&url));
+      std::fs::write(
+        &file_path,
+        serde_json::to_string_pretty(&package_info).unwrap(),
+      )
+      .unwrap();
+      std::fs::write(file_path.with_extension("headers"), "{}").unwrap();
+    }
+  }
 }
 
 async fn run_resolver_and_get_snapshot(
@@ -262,6 +314,15 @@ impl Default for SubsetRegistryApi {
 }
 
 impl SubsetRegistryApi {
+  pub fn get_all_package_infos(&self) -> Vec<NpmPackageInfo> {
+    self
+      .data
+      .borrow()
+      .values()
+      .map(|i| i.as_ref().clone())
+      .collect()
+  }
+
   pub fn get_version_info(&self, nv: &PackageNv) -> NpmPackageVersionInfo {
     self
       .data
@@ -337,5 +398,16 @@ fn packument_url(name: &str) -> String {
 }
 
 fn encode_package_name(name: &str) -> String {
-  name.replace("/", "%2F")
+  name.replace("/", "%2f")
+}
+
+fn sha256_hex(input: &str) -> String {
+  use hex;
+  use sha2::Digest;
+  use sha2::Sha256;
+
+  let mut hasher = Sha256::new();
+  hasher.update(input.as_bytes());
+  let result = hasher.finalize();
+  hex::encode(result)
 }


### PR DESCRIPTION
Outputs a folder that can be used with https://jsr.io/@david/bench-registry to run a private npm registry and compare the reproduction with other package managers.