### PR TITLE
feat: add NpmRegistryDefaultTarballUrlProvider

### DIFF
--- a/src/resolution/mod.rs
+++ b/src/resolution/mod.rs
@@ -17,6 +17,7 @@ pub use snapshot::AddPkgReqsResult;
 pub use snapshot::DefaultTarballUrlProvider;
 pub use snapshot::IncompleteSnapshotFromLockfileError;
 pub use snapshot::NpmPackagesPartitioned;
+pub use snapshot::NpmRegistryDefaultTarballUrlProvider;
 pub use snapshot::NpmResolutionSnapshot;
 pub use snapshot::PackageCacheFolderIdNotFoundError;
 pub use snapshot::PackageIdNotFoundError;

--- a/src/resolution/snapshot.rs
+++ b/src/resolution/snapshot.rs
@@ -884,6 +884,36 @@ pub trait DefaultTarballUrlProvider {
   fn default_tarball_url(&self, nv: &PackageNv) -> String;
 }
 
+impl<'a> Default for &'a dyn DefaultTarballUrlProvider {
+  fn default() -> Self {
+    &NpmRegistryDefaultTarballUrlProvider
+  }
+}
+
+/// `DefaultTarballUrlProvider` that uses the url of the real npm registry.
+pub struct NpmRegistryDefaultTarballUrlProvider;
+
+impl DefaultTarballUrlProvider for NpmRegistryDefaultTarballUrlProvider {
+  fn default_tarball_url(
+    &self,
+    nv: &deno_semver::package::PackageNv,
+  ) -> String {
+    let scope = nv.scope();
+    let package_name = if let Some(scope) = scope {
+      nv.name
+        .strip_prefix(scope)
+        .unwrap_or(&nv.name)
+        .trim_start_matches('/')
+    } else {
+      &nv.name
+    };
+    format!(
+      "https://registry.npmjs.org/{}/-/{}-{}.tgz",
+      nv.name, package_name, nv.version
+    )
+  }
+}
+
 fn dist_from_incomplete_package_info(
   id: &PackageNv,
   integrity: Option<&str>,

--- a/src/resolution/snapshot.rs
+++ b/src/resolution/snapshot.rs
@@ -884,7 +884,7 @@ pub trait DefaultTarballUrlProvider {
   fn default_tarball_url(&self, nv: &PackageNv) -> String;
 }
 
-impl<'a> Default for &'a dyn DefaultTarballUrlProvider {
+impl Default for &dyn DefaultTarballUrlProvider {
   fn default() -> Self {
     &NpmRegistryDefaultTarballUrlProvider
   }

--- a/src/resolution/snapshot.rs
+++ b/src/resolution/snapshot.rs
@@ -891,6 +891,7 @@ impl Default for &dyn DefaultTarballUrlProvider {
 }
 
 /// `DefaultTarballUrlProvider` that uses the url of the real npm registry.
+#[derive(Debug, Default, Clone)]
 pub struct NpmRegistryDefaultTarballUrlProvider;
 
 impl DefaultTarballUrlProvider for NpmRegistryDefaultTarballUrlProvider {


### PR DESCRIPTION
Shifts this down from the CLI (seems ok?)