### PR TITLE
fix: remove directories.bin

### DIFF
--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1282,7 +1282,7 @@ mod test {
         "peerDependenciesMeta": [],
         "os": {},
         "cpu": {},
-        "scripts": [],
+        "scripts": []
       }"#,
     );
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -250,9 +250,6 @@ pub struct NpmPackageVersionInfo {
   pub cpu: Vec<SmallStackString>,
   #[serde(default, skip_serializing_if = "HashMap::is_empty")]
   #[serde(deserialize_with = "deserializers::hashmap")]
-  pub directories: HashMap<SmallStackString, String>,
-  #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-  #[serde(deserialize_with = "deserializers::hashmap")]
   pub scripts: HashMap<SmallStackString, String>,
   #[serde(default, skip_serializing_if = "Option::is_none")]
   #[serde(deserialize_with = "deserializers::string")]
@@ -1286,7 +1283,6 @@ mod test {
         "os": {},
         "cpu": {},
         "scripts": [],
-        "directories": []
       }"#,
     );
 
@@ -1301,8 +1297,7 @@ mod test {
         "peerDependenciesMeta": true,
         "os": false,
         "cpu": true,
-        "scripts": false,
-        "directories": false
+        "scripts": false
       }"#,
     );
 
@@ -1317,8 +1312,7 @@ mod test {
         "peerDependenciesMeta": "",
         "os": "",
         "cpu": "",
-        "scripts": "",
-        "directories": ""
+        "scripts": ""
       }"#,
     );
 
@@ -1333,8 +1327,7 @@ mod test {
         "peerDependenciesMeta": -2.23,
         "os": -63.34,
         "cpu": 12,
-        "scripts": -1234.34,
-        "directories": 10
+        "scripts": -1234.34
       }"#,
     );
   }
@@ -1377,11 +1370,7 @@ mod test {
           "prop": 2
         },
         "valid"
-      ],
-      "directories": {
-        "bin": "good",
-        "bad": 5
-      }
+      ]
     }"#;
     let info: NpmPackageVersionInfo = serde_json::from_str(text).unwrap();
     assert_eq!(
@@ -1389,10 +1378,6 @@ mod test {
       HashMap::from([("value10".into(), "valid".into())])
     );
     assert_eq!(info.os, Vec::from(["valid".to_string()]));
-    assert_eq!(
-      info.directories,
-      HashMap::from([("bin".into(), "good".into())])
-    );
   }
 
   #[test]
@@ -1535,7 +1520,6 @@ mod test {
       os: Default::default(),
       cpu: Default::default(),
       scripts: Default::default(),
-      directories: Default::default(),
       deprecated: Default::default(),
     };
     let text = serde_json::to_string(&data).unwrap();

--- a/src/resolution/graph.rs
+++ b/src/resolution/graph.rs
@@ -765,8 +765,7 @@ impl Graph {
           deprecated: version_info.deprecated.clone(),
         }),
         is_deprecated: version_info.deprecated.is_some(),
-        has_bin: version_info.bin.is_some()
-          || version_info.directories.contains_key("bin"),
+        has_bin: version_info.bin.is_some(),
         has_scripts: version_info.scripts.contains_key("preinstall")
           || version_info.scripts.contains_key("install")
           || version_info.scripts.contains_key("postinstall"),


### PR DESCRIPTION
It seems like the "bin" object is always populated when publishing in the packument.